### PR TITLE
#9 앨범 피드에서 홈 버튼 누르면 홈 액티비티 2개 쌓이는 버그 수정

### DIFF
--- a/app/src/main/java/com/hschoi/collect/AlbumFeedActivity.kt
+++ b/app/src/main/java/com/hschoi/collect/AlbumFeedActivity.kt
@@ -259,8 +259,6 @@ class AlbumFeedActivity : AppCompatActivity() {
 //        cl_album_feed.layout_top_menu_album_feed.cl_bottom_menu_bar.setBackgroundColor(color) // 이렇게 하면 안됨
 
         layout_bottom_menu_bar.iv_menu_home.setOnClickListener {
-            val intent = Intent(this, MainActivity::class.java)
-            startActivity(intent)
             finish()
         }
 


### PR DESCRIPTION
singleTop으로 수정하면서 메인 액티비티 여러개 생성됨
홈 버튼 누르면 현재 액티비티 종료하는 방식으로 수정함
resolve #9 